### PR TITLE
Added `init()` from `colorama` modules

### DIFF
--- a/PyCommands/__init__.py
+++ b/PyCommands/__init__.py
@@ -1,6 +1,9 @@
 from .commands import *
 from .constants import *
 from .core import *
+from colorama import init
+
+init()
 
 __title__ = "PyCommands"
 __version__="0.3.2"


### PR DESCRIPTION
The most important thing if you want to use the `colorama` module is the `init` function. Because not all devices support [Ansi](https://en.wikipedia.org/wiki/ANSI_escape_code) color, that's why `init` is very important. if you want more simple and easy, use [`colorgb`](https://pypi.org/project/colorgb/) packages. mine btw :3